### PR TITLE
Making it work on OS X

### DIFF
--- a/commons-eid-client/src/main/java/be/fedict/commons/eid/client/BeIDCard.java
+++ b/commons-eid-client/src/main/java/be/fedict/commons/eid/client/BeIDCard.java
@@ -1127,6 +1127,14 @@ public class BeIDCard {
 
 	private ResponseAPDU transmit(final CommandAPDU commandApdu)
 			throws CardException {
+		return transmit(commandApdu, 0);
+	}
+
+	private ResponseAPDU transmit(final CommandAPDU commandApdu,
+			final int attempt) throws CardException {
+		if (attempt >= 32)
+			throw new CardException("Could not obtain response.");
+
 		ResponseAPDU responseApdu = this.cardChannel.transmit(commandApdu);
 		if (0x6c == responseApdu.getSW1()) {
 			/*
@@ -1140,7 +1148,32 @@ public class BeIDCard {
 			} catch (final InterruptedException e) {
 				throw new RuntimeException("cannot sleep");
 			}
-			responseApdu = this.cardChannel.transmit(commandApdu);
+			CommandAPDU newCommandApdu = new CommandAPDU(commandApdu.getCLA(),
+				commandApdu.getINS(), commandApdu.getP1(), commandApdu.getP2(),
+				commandApdu.getData(), responseApdu.getSW2());
+			responseApdu = transmit(newCommandApdu, attempt + 1);
+		} else if (0x61 == responseApdu.getSW1()) {
+			/*
+			 * Issue a GET RESPONSE command to retrieve the remaining data.
+			 */
+			int le = responseApdu.getSW2();
+			if (le == 0)
+				le = 0xff;
+			CommandAPDU newCommandApdu = new CommandAPDU(0x00, 0xC0, 0x00,
+					0x00, le);
+			ResponseAPDU newResponseApdu = transmit(newCommandApdu,
+					attempt + 1);
+
+			/*
+			 * Combine the previously received data with the new response.
+			 */
+			byte[] oldData = responseApdu.getData();
+			byte[] newResponse = newResponseApdu.getBytes();
+			byte[] combined = new byte[oldData.length + newResponse.length];
+			System.arraycopy(oldData, 0, combined, 0, oldData.length);
+			System.arraycopy(newResponse, 0, combined, oldData.length,
+					newResponse.length);
+			responseApdu = new ResponseAPDU(combined);
 		}
 		return responseApdu;
 	}


### PR DESCRIPTION
Since Sun's smartcardio library constantly crashes on OS X with 64-bit java [1], I switched to Intarsys' alternative implementation [2]. I had to make some changes to make it work though:

1. The handling of 0x6c ("Wrong length Le") APDU responses didn't work until I actually changed the length in the new request. 

2. I also added handling for 0x61 ("More date bytes are available") APDU responses.

Both cases are normally handled internally by the Sun's smartcardio library, so they shouldn't even occur. That's why I don't think this change will have any impact when using the default implementation, although I haven't tested this.

I'm not sure why Intarsys opted not to handle those responses internally (and therefore be more compatible with Sun's implementation), but I do know that this mechanism can be disabled in Sun's implementation as well. So for people who wish to disable it (required to make certain types of cards work [3]), this change may be useful as well.

[1] https://discussions.apple.com/message/21436263
[2] https://github.com/intarsys/smartcard-io
[3] https://ridrix.wordpress.com/2009/07/12/design-error-in-javax-smartcardio/