### PR TITLE
Use MaskedDate for dateOfBirth in Identity as a way of supporting partial birth dates.

### DIFF
--- a/commons-eid-consumer/src/main/java/be/fedict/commons/eid/consumer/DateMask.java
+++ b/commons-eid-consumer/src/main/java/be/fedict/commons/eid/consumer/DateMask.java
@@ -1,5 +1,6 @@
 /*
  * Commons eID Project.
+ * Copyright (C) 2008-2017 FedICT.
  * Copyright (C) 2017 Peter Mylemans.
  *
  * This is free software; you can redistribute it and/or modify it

--- a/commons-eid-consumer/src/main/java/be/fedict/commons/eid/consumer/DateMask.java
+++ b/commons-eid-consumer/src/main/java/be/fedict/commons/eid/consumer/DateMask.java
@@ -1,0 +1,37 @@
+/*
+ * Commons eID Project.
+ * Copyright (C) 2008-2016 FedICT.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version
+ * 3.0 as published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, see
+ * http://www.gnu.org/licenses/.
+ */
+
+package be.fedict.commons.eid.consumer;
+
+/**
+ * DateMask is an an enum to support partial date information.
+ *
+ * @author Peter Mylemans
+ */
+public enum DateMask {
+
+    /**
+     * Mask that signifies only the year is set.
+     */
+    YYYY,
+
+    /**
+     * Mask that signifies a year, month and day of month is set.
+     */
+    YYYY_MM_DD;
+}

--- a/commons-eid-consumer/src/main/java/be/fedict/commons/eid/consumer/DateMask.java
+++ b/commons-eid-consumer/src/main/java/be/fedict/commons/eid/consumer/DateMask.java
@@ -1,6 +1,6 @@
 /*
  * Commons eID Project.
- * Copyright (C) 2008-2016 FedICT.
+ * Copyright (C) 2017 Peter Mylemans.
  *
  * This is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version

--- a/commons-eid-consumer/src/main/java/be/fedict/commons/eid/consumer/Identity.java
+++ b/commons-eid-consumer/src/main/java/be/fedict/commons/eid/consumer/Identity.java
@@ -25,6 +25,7 @@ import java.util.GregorianCalendar;
 import be.fedict.commons.eid.consumer.tlv.ChipNumberDataConvertor;
 import be.fedict.commons.eid.consumer.tlv.ConvertData;
 import be.fedict.commons.eid.consumer.tlv.DateOfBirthDataConvertor;
+import be.fedict.commons.eid.consumer.tlv.DateOfBirthMaskDataConvertor;
 import be.fedict.commons.eid.consumer.tlv.DocumentTypeConvertor;
 import be.fedict.commons.eid.consumer.tlv.GenderDataConvertor;
 import be.fedict.commons.eid.consumer.tlv.OriginalData;
@@ -91,6 +92,10 @@ public class Identity implements Serializable {
 	@TlvField(12)
 	@ConvertData(DateOfBirthDataConvertor.class)
 	public GregorianCalendar dateOfBirth;
+
+	@TlvField(12)
+	@ConvertData(DateOfBirthMaskDataConvertor.class)
+	public DateMask dateOfBirthMask;
 
 	@TlvField(13)
 	@ConvertData(GenderDataConvertor.class)
@@ -180,6 +185,10 @@ public class Identity implements Serializable {
 
 	public GregorianCalendar getDateOfBirth() {
 		return this.dateOfBirth;
+	}
+
+	public DateMask getDateOfBirthMask() {
+		return dateOfBirthMask;
 	}
 
 	public Gender getGender() {

--- a/commons-eid-consumer/src/main/java/be/fedict/commons/eid/consumer/tlv/DateOfBirthMaskDataConvertor.java
+++ b/commons-eid-consumer/src/main/java/be/fedict/commons/eid/consumer/tlv/DateOfBirthMaskDataConvertor.java
@@ -1,5 +1,6 @@
 /*
  * Commons eID Project.
+ * Copyright (C) 2008-2017 FedICT.
  * Copyright (C) 2017 Peter Mylemans.
  *
  * This is free software; you can redistribute it and/or modify it

--- a/commons-eid-consumer/src/main/java/be/fedict/commons/eid/consumer/tlv/DateOfBirthMaskDataConvertor.java
+++ b/commons-eid-consumer/src/main/java/be/fedict/commons/eid/consumer/tlv/DateOfBirthMaskDataConvertor.java
@@ -1,6 +1,6 @@
 /*
  * Commons eID Project.
- * Copyright (C) 2008-2016 FedICT.
+ * Copyright (C) 2017 Peter Mylemans.
  *
  * This is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version

--- a/commons-eid-consumer/src/main/java/be/fedict/commons/eid/consumer/tlv/DateOfBirthMaskDataConvertor.java
+++ b/commons-eid-consumer/src/main/java/be/fedict/commons/eid/consumer/tlv/DateOfBirthMaskDataConvertor.java
@@ -1,0 +1,54 @@
+/*
+ * Commons eID Project.
+ * Copyright (C) 2008-2016 FedICT.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version
+ * 3.0 as published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, see 
+ * http://www.gnu.org/licenses/.
+ */
+
+package be.fedict.commons.eid.consumer.tlv;
+
+import java.io.UnsupportedEncodingException;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import be.fedict.commons.eid.consumer.DateMask;
+
+/**
+ * Convertor for eID date of birth mask field.
+ *
+ * @author Peter Mylmeans
+ */
+public class DateOfBirthMaskDataConvertor implements DataConvertor<DateMask> {
+
+    private static final Log LOG = LogFactory.getLog(DateOfBirthMaskDataConvertor.class);
+
+    @Override
+    public DateMask convert(final byte[] value) throws DataConvertorException {
+        String dateOfBirthStr;
+        try {
+            dateOfBirthStr = new String(value, "UTF-8").trim();
+        } catch (final UnsupportedEncodingException uex) {
+            throw new DataConvertorException("UTF-8 not supported");
+        }
+        LOG.debug("\"" + dateOfBirthStr + "\"");
+
+        if (dateOfBirthStr.length() == 4) {
+            return DateMask.YYYY;
+        } else {
+            return DateMask.YYYY_MM_DD;
+        }
+    }
+
+}

--- a/commons-eid-consumer/src/test/java/test/unit/be/fedict/commons/eid/consumer/tlv/TlvParserTest.java
+++ b/commons-eid-consumer/src/test/java/test/unit/be/fedict/commons/eid/consumer/tlv/TlvParserTest.java
@@ -38,6 +38,7 @@ import org.apache.commons.logging.LogFactory;
 import org.junit.Test;
 
 import be.fedict.commons.eid.consumer.Address;
+import be.fedict.commons.eid.consumer.DateMask;
 import be.fedict.commons.eid.consumer.DocumentType;
 import be.fedict.commons.eid.consumer.Gender;
 import be.fedict.commons.eid.consumer.Identity;
@@ -92,6 +93,7 @@ public class TlvParserTest {
 		assertNotNull(identity.dateOfBirth);
 		LOG.debug("date of birth: " + identity.dateOfBirth.getTime());
 		assertEquals(new GregorianCalendar(1971, 0, 1), identity.dateOfBirth);
+		assertEquals(DateMask.YYYY_MM_DD, identity.dateOfBirthMask);
 		LOG.debug("special status: " + identity.specialStatus);
 		assertEquals(SpecialStatus.NO_STATUS, identity.specialStatus);
 		assertNull(identity.getSpecialOrganisation());
@@ -141,6 +143,7 @@ public class TlvParserTest {
 		assertNotNull(identity.dateOfBirth);
 		LOG.debug("date of birth: " + identity.dateOfBirth.getTime());
 		assertEquals(new GregorianCalendar(1971, 0, 1), identity.dateOfBirth);
+		assertEquals(DateMask.YYYY_MM_DD, identity.dateOfBirthMask);
 		assertNull(identity.getSpecialOrganisation());
 	}
 
@@ -224,6 +227,7 @@ public class TlvParserTest {
 		final byte[] yearOnlyTLV = new byte[]{12, 4, '1', '9', '8', '4'};
 		final Identity identity = TlvParser.parse(yearOnlyTLV, Identity.class);
 		assertEquals(1984, identity.getDateOfBirth().get(Calendar.YEAR));
+		assertEquals(DateMask.YYYY, identity.dateOfBirthMask);
 	}
 
 	@Test


### PR DESCRIPTION
Identity currently stores partial birth dates (when only year of birth is known) as a GregorianCalendar set to January, 1st. Currently client applications have no way of knowing whether the person was actually born on January, 1st or the data is unknown.

I propose to replace the GregorianCalendar with a MaskedDate that contains the date as a GregorianCalendar (as before) and a mask telling the user which fields are set. It also contains two convience methods "getTime()" and "get(int)" to break as little API as necessary.

Note that the Java 8 solution would be to use a Temporal and fill it with either a LocalDate or a Year, but this would require the project to bump its minimal Java version from Java 7 to Java 8, which might be a problem for some projects. 
