### PR TITLE
Version bumped commons-lang(3) due to vulnerability.

### DIFF
--- a/commons-eid-client/pom.xml
+++ b/commons-eid-client/pom.xml
@@ -26,8 +26,8 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/commons-eid-client/src/main/java/be/fedict/commons/eid/client/impl/CardTerminalsProxy.java
+++ b/commons-eid-client/src/main/java/be/fedict/commons/eid/client/impl/CardTerminalsProxy.java
@@ -30,9 +30,9 @@ import javax.smartcardio.CardTerminal;
 import javax.smartcardio.CardTerminals;
 import javax.smartcardio.TerminalFactory;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
 
 import be.fedict.commons.eid.client.spi.Logger;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 /**
  * Based on code from BOSA, but reworked a bit for older Java 7 runtimes.

--- a/pom.xml
+++ b/pom.xml
@@ -75,9 +75,9 @@
 				<version>2.21.0</version>
 			</dependency>
 			<dependency>
-				<groupId>commons-lang</groupId>
-				<artifactId>commons-lang</artifactId>
-				<version>2.6</version>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-lang3</artifactId>
+				<version>3.20.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
This fixes the commons-lang vulnerabilities mentioned in https://github.com/e-Contract/commons-eid/issues/20

I see you already fixed the bouncy castle issue.  
Can you please merge my commit and release this as version 1.2.1, thanks!